### PR TITLE
Fix linting errors blocking Dependabot PRs

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -32,6 +32,7 @@ func main() {
 		interval    = flag.Duration("interval", 2*time.Second, "Update interval")
 		showVersion = flag.Bool("version", false, "Show version information")
 	)
+
 	flag.Parse()
 
 	if *showVersion {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -638,6 +638,7 @@ func (c *Config) ValidateDetailed() []ValidationError {
 
 		if brightness, ok := matrix["brightness"]; ok {
 			var brightnessVal float64
+
 			switch v := brightness.(type) {
 			case int:
 				brightnessVal = float64(v)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -198,18 +198,23 @@ display:
 				if cfg.Matrix.BaudRate != 9600 {
 					t.Errorf("Expected baud rate 9600, got %d", cfg.Matrix.BaudRate)
 				}
+
 				if cfg.Matrix.Brightness != 50 {
 					t.Errorf("Expected brightness 50, got %d", cfg.Matrix.Brightness)
 				}
+
 				if cfg.Stats.CollectInterval != 5*time.Second {
 					t.Errorf("Expected collect interval 5s, got %v", cfg.Stats.CollectInterval)
 				}
+
 				if !cfg.Stats.EnableNetwork {
 					t.Error("Expected network monitoring to be enabled")
 				}
+
 				if cfg.Display.Mode != stringGradient {
 					t.Errorf("Expected display mode 'gradient', got %s", cfg.Display.Mode)
 				}
+
 				if cfg.Display.PrimaryMetric != "memory" {
 					t.Errorf("Expected primary metric 'memory', got %s", cfg.Display.PrimaryMetric)
 				}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -91,6 +91,7 @@ func NewLogger(config Config) (*Logger, error) {
 
 	// Convert level
 	var level slog.Level
+
 	switch config.Level {
 	case LevelDebug:
 		level = slog.LevelDebug

--- a/internal/visualizer/mapper.go
+++ b/internal/visualizer/mapper.go
@@ -201,12 +201,14 @@ func (v *Visualizer) CreateCustomPattern(width, height int, data []float64) ([39
 		return pixels, fmt.Errorf("data length mismatch: expected %d, got %d", width*height, len(data))
 	}
 
-	for i, value := range data {
-		if i >= len(pixels) {
-			break
-		}
+	// Use explicit bounds to satisfy gosec linter
+	maxLen := len(pixels)
+	if len(data) < maxLen {
+		maxLen = len(data)
+	}
 
-		normalized := math.Max(0, math.Min(1, value))
+	for i := 0; i < maxLen; i++ {
+		normalized := math.Max(0, math.Min(1, data[i]))
 		pixels[i] = byte(normalized * 255)
 	}
 


### PR DESCRIPTION
## Summary

Fixes 9 linting errors that were causing all Dependabot PRs to fail at the quality check stage. These errors were preventing legitimate dependency updates from being merged.

## Changes

### Security Fix (gosec G602)
- **File**: `internal/visualizer/mapper.go:210`
- **Issue**: Potential slice index out of range
- **Fix**: Replaced range-with-break pattern with explicit iteration using pre-calculated bounds

### Whitespace Fixes (wsl)
Added blank lines before specific statements to comply with whitespace linting rules:

- `cmd/simulator/main.go:35` - Before `flag.Parse()` call
- `internal/config/config.go:641` - Before switch statement  
- `internal/config/config_test.go` - Before 5 if statements (lines 201, 204, 207, 210, 213)
- `internal/logging/logger.go:94` - Before switch statement

## Test Results

✅ All linting checks pass (0 issues)
✅ All tests pass with race detector
✅ Coverage: 51.1%
✅ GitHub Actions workflow verified locally with `gh act`

## Impact

- **Breaking Changes**: None
- **Behavioral Changes**: None
- **Code Quality**: Improved security and readability

After this PR merges, the following Dependabot PRs should pass CI:
- #18 - Bump golang.org/x/sys from 0.36.0 to 0.38.0
- #17 - Bump actions/download-artifact from 5 to 6
- #16 - Bump actions/upload-artifact from 4 to 5
- #15 - Bump github/codeql-action from 3 to 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation test suite to comprehensively verify configuration settings including display modes, metric preferences, collection intervals, brightness levels, and network monitoring options.

* **Refactor**
  * Optimized internal iteration and bounds handling to improve code reliability and standards compliance.

* **Style**
  * Applied minor formatting improvements throughout the codebase for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->