### PR TITLE
fix: use placeholders in agent/skill docs to avoid grep false positives

### DIFF
--- a/.claude/agents/go-version-updater.md
+++ b/.claude/agents/go-version-updater.md
@@ -29,12 +29,12 @@ Search the repository for all Go version references. The known locations are:
 
 | File | Pattern | Example |
 |------|---------|---------|
-| `go.mod` | `go X.Y.Z` | `go 1.25.4` |
-| `Dockerfile` | `golang:X.Y.Z-alpine` | `golang:1.25.4-alpine` |
-| `.github/workflows/ci.yml` | `GO_VERSION: "X.Y.Z"` and `go-version: ['X.Y.Z']` | `GO_VERSION: "1.25.4"` |
-| `.github/workflows/release.yml` | `GO_VERSION: 'X.Y.Z'` | `GO_VERSION: '1.25.4'` |
-| `README.md` | `Go X.Y or later` and `Go X.Y+` | `Go 1.25 or later`, `Go 1.25+` |
-| `CONTRIBUTING.md` | `Go X.Y` | `Go 1.25` |
+| `go.mod` | `go X.Y.Z` | `go <version>` |
+| `Dockerfile` | `golang:X.Y.Z-alpine` | `golang:<version>-alpine` |
+| `.github/workflows/ci.yml` | `GO_VERSION: "X.Y.Z"` and `go-version: ['X.Y.Z']` | `GO_VERSION: "<version>"` |
+| `.github/workflows/release.yml` | `GO_VERSION: 'X.Y.Z'` | `GO_VERSION: '<version>'` |
+| `README.md` | `Go X.Y or later` and `Go X.Y+` | `Go <major>.<minor> or later` |
+| `CONTRIBUTING.md` | `Go X.Y` | `Go <major>.<minor>` |
 
 Additionally, run a grep across the entire repo to catch any other references to the old version.
 
@@ -50,7 +50,7 @@ For each file found in Step 3:
 ### Step 5: Validate
 
 1. Run `go mod tidy` to ensure `go.mod` and `go.sum` are consistent
-2. Run a final grep for the OLD version string to confirm no references remain
+2. Run a final grep for the OLD version string to confirm no references remain (exclude `go.sum`, `.git/`, `.claude/`, and binary files from this check)
 3. Report all changes made
 
 ## Output Format

--- a/.claude/skills/update-go-version.md
+++ b/.claude/skills/update-go-version.md
@@ -27,7 +27,7 @@ If the repo is already on the latest version, inform the user and stop. Otherwis
 
 Update Go version references in ALL of these locations:
 
-**Build files (use full patch version, e.g., `1.26.0`):**
+**Build files (use full patch version, e.g., `X.Y.Z`):**
 - `go.mod` - the `go` directive
 - `Dockerfile` - the `golang:X.Y.Z-alpine` builder image
 
@@ -35,17 +35,17 @@ Update Go version references in ALL of these locations:
 - `.github/workflows/ci.yml` - `GO_VERSION` env var and `go-version` matrix
 - `.github/workflows/release.yml` - `GO_VERSION` env var
 
-**Documentation (use minor version, e.g., `1.26`):**
+**Documentation (use minor version, e.g., `X.Y`):**
 - `README.md` - minimum version requirements and install instructions
 - `CONTRIBUTING.md` - prerequisites section
 
 ### 5. Run Grep Safety Check
 
 After making changes, grep the entire repository for the OLD version string to ensure nothing was missed. The old version could appear as:
-- The full patch version (e.g., `1.25.4`)
-- The minor version in docs (e.g., `1.25`)
+- The full patch version (e.g., `<old_major>.<old_minor>.<old_patch>`)
+- The minor version in docs (e.g., `<old_major>.<old_minor>`)
 
-Exclude `go.sum`, `.git/`, and binary files from this check.
+Exclude `go.sum`, `.git/`, `.claude/`, and binary files from this check.
 
 ### 6. Tidy Modules
 


### PR DESCRIPTION
## Summary

- Replace hard-coded version examples (`1.25.4`, `1.25`) with generic placeholders in agent and skill documentation
- Add `.claude/` to grep exclusion list to prevent self-matching during version validation

Addresses Copilot review comments on #32.

## Test plan

- [ ] Verify no literal old-version strings remain in `.claude/agents/` or `.claude/skills/`
- [ ] Grep safety check instructions now explicitly exclude `.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)