### PR TITLE
feat: ✨ Game of Life and multi-face animations for dual LED matrices

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -37,12 +37,13 @@ stats:
     disk_critical: 95.0      # Disk usage critical threshold (%)
 
 display:
-  update_rate: 200ms         # How often to update the display (fast for animations)
-  mode: "animations"         # Display mode: percentage, gradient, activity, status, custom, animations
+  update_rate: 1s            # How often to update the display
+  mode: "percentage"         # Display mode: percentage, gradient, activity, status, custom, animations
   primary_metric: "cpu"      # Primary metric to display: cpu, memory, disk, network
   show_activity: true        # Show activity indicators
   enable_animation: false    # Enable pattern animations
   custom_patterns: {}        # Custom pattern configurations
+  # To enable animations mode on dual matrices, set mode: "animations" and update_rate: "200ms"
 
 daemon:
   name: "framework-led-daemon"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -37,8 +37,8 @@ stats:
     disk_critical: 95.0      # Disk usage critical threshold (%)
 
 display:
-  update_rate: 1s            # How often to update the display
-  mode: "percentage"         # Display mode: percentage, gradient, activity, status, custom
+  update_rate: 200ms         # How often to update the display (fast for animations)
+  mode: "animations"         # Display mode: percentage, gradient, activity, status, custom, animations
   primary_metric: "cpu"      # Primary metric to display: cpu, memory, disk, network
   show_activity: true        # Show activity indicators
   enable_animation: false    # Enable pattern animations

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -263,6 +263,7 @@ func (c *Config) Validate() error {
 		"activity":   true,
 		"status":     true,
 		"custom":     true,
+		"animations": true,
 	}
 	if !validModes[c.Display.Mode] {
 		return fmt.Errorf("invalid display mode: %s", c.Display.Mode)
@@ -536,12 +537,13 @@ func (c *Config) ValidateDetailed() []ValidationError {
 		"activity":   true,
 		"status":     true,
 		"custom":     true,
+		"animations": true,
 	}
 	if !validModes[c.Display.Mode] {
 		errors = append(errors, ValidationError{
 			Field:   "display.mode",
 			Value:   c.Display.Mode,
-			Message: "must be one of: percentage, gradient, activity, status, custom",
+			Message: "must be one of: percentage, gradient, activity, status, custom, animations",
 		})
 	}
 

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -753,6 +753,7 @@ func (s *Service) SetDisplayMode(mode string) error {
 		"activity":   true,
 		"status":     true,
 		"custom":     true,
+		"animations": true,
 	}
 	if !validModes[mode] {
 		return fmt.Errorf("invalid display mode: %s", mode)

--- a/internal/matrix/display.go
+++ b/internal/matrix/display.go
@@ -377,6 +377,9 @@ func (mdm *MultiDisplayManager) HasMultipleDisplays() bool {
 // StageColumn / FlushColumns protocol. frame[col][row] is the brightness (0-255)
 // for each of the 9 columns and 34 rows.
 func (mdm *MultiDisplayManager) DrawFrame(name string, frame [9][34]byte) error {
+	mdm.mu.Lock()
+	defer mdm.mu.Unlock()
+
 	client := mdm.multiClient.GetClient(name)
 	if client == nil {
 		return fmt.Errorf("matrix %q not found", name)
@@ -388,5 +391,9 @@ func (mdm *MultiDisplayManager) DrawFrame(name string, frame [9][34]byte) error 
 		}
 	}
 
-	return client.FlushColumns()
+	if err := client.FlushColumns(); err != nil {
+		return fmt.Errorf("flushing columns for matrix %q: %w", name, err)
+	}
+
+	return nil
 }

--- a/internal/matrix/display.go
+++ b/internal/matrix/display.go
@@ -372,3 +372,21 @@ func (mdm *MultiDisplayManager) HasMultipleDisplays() bool {
 
 	return len(mdm.displays) > 1
 }
+
+// DrawFrame renders an arbitrary pixel frame on the named matrix using the
+// StageColumn / FlushColumns protocol. frame[col][row] is the brightness (0-255)
+// for each of the 9 columns and 34 rows.
+func (mdm *MultiDisplayManager) DrawFrame(name string, frame [9][34]byte) error {
+	client := mdm.multiClient.GetClient(name)
+	if client == nil {
+		return fmt.Errorf("matrix %q not found", name)
+	}
+
+	for col := byte(0); col < 9; col++ {
+		if err := client.StageColumn(col, frame[col]); err != nil {
+			return fmt.Errorf("staging column %d: %w", col, err)
+		}
+	}
+
+	return client.FlushColumns()
+}

--- a/internal/matrix/drawframe_test.go
+++ b/internal/matrix/drawframe_test.go
@@ -34,7 +34,7 @@ func TestDrawFrame_AllColumnsStaged(t *testing.T) {
 	// FlushColumns write:     [MagicByte1, MagicByte2, CmdFlushCols]                =  3 bytes
 	const wantLen = 9*38 + 3
 	if got := len(mockPort.writeData); got != wantLen {
-		t.Errorf("DrawFrame() wrote %d bytes, want %d", got, wantLen)
+		t.Fatalf("DrawFrame() wrote %d bytes, want %d", got, wantLen)
 	}
 
 	// Verify each column's magic header and column-index byte.

--- a/internal/matrix/drawframe_test.go
+++ b/internal/matrix/drawframe_test.go
@@ -1,0 +1,109 @@
+package matrix
+
+import (
+	"fmt"
+	"testing"
+)
+
+// newMDMWithMock builds a MultiDisplayManager backed by a single MockPort-wired Client.
+func newMDMWithMock(name string) (*MultiDisplayManager, *MockPort) {
+	mockPort := NewMockPort()
+	client := &Client{port: mockPort}
+	mc := &MultiClient{
+		clients: map[string]*Client{name: client},
+		config:  make(map[string]*SingleMatrixConfig),
+	}
+	return NewMultiDisplayManager(mc, "split"), mockPort
+}
+
+func TestDrawFrame_AllColumnsStaged(t *testing.T) {
+	mdm, mockPort := newMDMWithMock("primary")
+
+	var frame [9][34]byte
+	for col := 0; col < 9; col++ {
+		for row := 0; row < 34; row++ {
+			frame[col][row] = byte(col*10 + row%10)
+		}
+	}
+
+	if err := mdm.DrawFrame("primary", frame); err != nil {
+		t.Fatalf("DrawFrame() unexpected error: %v", err)
+	}
+
+	// Each StageColumn write: [MagicByte1, MagicByte2, CmdStageCol, col, 34 pixels] = 38 bytes
+	// FlushColumns write:     [MagicByte1, MagicByte2, CmdFlushCols]                =  3 bytes
+	const wantLen = 9*38 + 3
+	if got := len(mockPort.writeData); got != wantLen {
+		t.Errorf("DrawFrame() wrote %d bytes, want %d", got, wantLen)
+	}
+
+	// Verify each column's magic header and column-index byte.
+	for col := 0; col < 9; col++ {
+		base := col * 38
+		if mockPort.writeData[base] != MagicByte1 {
+			t.Errorf("col %d byte[0] = %#x, want MagicByte1 %#x", col, mockPort.writeData[base], MagicByte1)
+		}
+		if mockPort.writeData[base+1] != MagicByte2 {
+			t.Errorf("col %d byte[1] = %#x, want MagicByte2 %#x", col, mockPort.writeData[base+1], MagicByte2)
+		}
+		if mockPort.writeData[base+2] != CmdStageCol {
+			t.Errorf("col %d byte[2] = %#x, want CmdStageCol %#x", col, mockPort.writeData[base+2], CmdStageCol)
+		}
+		if mockPort.writeData[base+3] != byte(col) {
+			t.Errorf("col %d column-index byte = %d, want %d", col, mockPort.writeData[base+3], col)
+		}
+	}
+}
+
+func TestDrawFrame_FlushColumnsCalledOnce(t *testing.T) {
+	mdm, mockPort := newMDMWithMock("primary")
+
+	if err := mdm.DrawFrame("primary", [9][34]byte{}); err != nil {
+		t.Fatalf("DrawFrame() unexpected error: %v", err)
+	}
+
+	// FlushColumns is a 3-byte command; it should appear exactly once, at the end.
+	flushBase := 9 * 38
+	if len(mockPort.writeData) < flushBase+3 {
+		t.Fatalf("not enough bytes written: got %d", len(mockPort.writeData))
+	}
+	if mockPort.writeData[flushBase+2] != CmdFlushCols {
+		t.Errorf("FlushColumns byte = %#x, want CmdFlushCols %#x", mockPort.writeData[flushBase+2], CmdFlushCols)
+	}
+}
+
+func TestDrawFrame_PixelDataCorrect(t *testing.T) {
+	mdm, mockPort := newMDMWithMock("primary")
+
+	var frame [9][34]byte
+	frame[3][7] = 0xAB
+
+	if err := mdm.DrawFrame("primary", frame); err != nil {
+		t.Fatalf("DrawFrame() unexpected error: %v", err)
+	}
+
+	// Col 3 packet starts at byte 3*38. Pixel bytes start at offset +4 (after header+col).
+	col3PixelBase := 3*38 + 4
+	if got := mockPort.writeData[col3PixelBase+7]; got != 0xAB {
+		t.Errorf("pixel[col=3][row=7] = %#x, want 0xAB", got)
+	}
+}
+
+func TestDrawFrame_UnknownMatrix(t *testing.T) {
+	mdm, _ := newMDMWithMock("primary")
+
+	err := mdm.DrawFrame("secondary", [9][34]byte{})
+	if err == nil {
+		t.Error("DrawFrame() with unknown matrix: expected error, got nil")
+	}
+}
+
+func TestDrawFrame_StageColumnErrorPropagated(t *testing.T) {
+	mdm, mockPort := newMDMWithMock("primary")
+	mockPort.writeError = fmt.Errorf("port write failure")
+
+	err := mdm.DrawFrame("primary", [9][34]byte{})
+	if err == nil {
+		t.Error("DrawFrame() should propagate StageColumn port error")
+	}
+}

--- a/internal/visualizer/faces.go
+++ b/internal/visualizer/faces.go
@@ -1,0 +1,253 @@
+package visualizer
+
+import "time"
+
+const (
+	faceWidth      = 9  // physical matrix columns
+	faceTileHeight = 10 // rows per face tile
+)
+
+// facePattern describes one compact facial expression fitting in a 9×10 tile.
+// rows[r] is a 9-character string; '#'=255, 'o'=160 (soft), '.'=0.
+type facePattern struct {
+	rows    [faceTileHeight]string
+	holdFor time.Duration
+}
+
+// toTile converts the row-major string pattern to a column-major [9][10]byte tile.
+func (fp *facePattern) toTile() [faceWidth][faceTileHeight]byte {
+	var tile [faceWidth][faceTileHeight]byte
+	for row, s := range fp.rows {
+		for col := 0; col < faceWidth && col < len(s); col++ {
+			switch s[col] {
+			case '#':
+				tile[col][row] = 255
+			case 'o':
+				tile[col][row] = 160
+			}
+		}
+	}
+	return tile
+}
+
+// Each face is a 9-wide × 10-tall pixel tile.
+// Layout within the tile:
+//   rows 0-1  : top margin / brows
+//   rows 2-3  : eyes
+//   row  4    : gap
+//   rows 5-6  : mouth
+//   rows 7-9  : bottom margin
+var facePatterns = []facePattern{
+	// 0 — Kawaii Happy (^‿^)
+	{holdFor: 6 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".##...##.", // 2 eyes
+		".##...##.", // 3
+		".........", // 4
+		"..#...#..", // 5 smile corners (high)
+		"...###...", // 6 smile centre (low) → arc up = smile
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 1 — Kawaii UwU (ᵕ̈)
+	{holdFor: 5 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".#.#.#.#.", // 2 U-eyes open tops
+		".###.###.", // 3 U-eyes solid bottoms
+		".........", // 4
+		"...#.#...", // 5 ω mouth humps
+		"..#...#..", // 6 ω mouth outer dips
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 2 — Kawaii Sleepy (-ᴗ-)
+	{holdFor: 10 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".........", // 2
+		".##...##.", // 3 flat single-row half-closed eyes
+		".........", // 4
+		".........", // 5
+		"...###...", // 6 flat mouth
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 3 — Kawaii Surprised (O_O)
+	{holdFor: 4 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		"..#...#..", // 1 hollow O eyes top
+		".#.#.#.#.", // 2 hollow O eyes sides
+		"..#...#..", // 3 hollow O eyes bottom
+		".........", // 4
+		"....#....", // 5 small O mouth top
+		"...#.#...", // 6 small O mouth sides
+		"....#....", // 7 small O mouth bottom
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 4 — Anime Neutral (-_-)
+	{holdFor: 5 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".........", // 2
+		".#######.", // 3 single long flat eyes
+		".........", // 4
+		".........", // 5
+		"...###...", // 6 flat mouth
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 5 — Anime Sad (T_T) with single tear
+	{holdFor: 7 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".##...##.", // 2 eyes
+		".##...##.", // 3
+		".#.......", // 4 tear drop (left)
+		"...###...", // 5 frown top (centre high)
+		"..#...#..", // 6 frown corners (low) → arc down = frown
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 6 — Punk Smirk (one eye wink, mouth raised on right)
+	{holdFor: 5 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".##......", // 2 left eye top only
+		".##...##.", // 3 left eye bottom + right wink (single row)
+		".........", // 4
+		".....##..", // 5 smirk right side raised
+		"....###..", // 6 smirk body (leans right)
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 7 — Punk Mean (ò_ó) — angry brows, squint, tight frown
+	{holdFor: 5 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".#.....#.", // 1 angry brow outer ends
+		"..#...#..", // 2 angry brow inner (diagonal slant toward centre)
+		".##...##.", // 3 squinting eyes
+		".........", // 4
+		"...###...", // 5 tight frown top (centre high)
+		"..#...#..", // 6 tight frown corners (low) → frown
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 8 — Don't Care (._.)
+	{holdFor: 8 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".........", // 1
+		".........", // 2
+		"...#.#...", // 3 tiny dot eyes
+		".........", // 4
+		".........", // 5
+		"...###...", // 6 flat mouth
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 9 — Dead Inside (x_x)
+	{holdFor: 7 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		".#.#.#.#.", // 1 X eyes upper diagonals
+		"..#...#..", // 2 X eyes centres
+		".#.#.#.#.", // 3 X eyes lower diagonals
+		".........", // 4
+		"..#####..", // 5 flat mouth
+		".........", // 6
+		".........", // 7
+		".........", // 8
+		".........", // 9
+	}},
+
+	// 10 — Genki / Energetic (^u^)
+	{holdFor: 4 * time.Second, rows: [faceTileHeight]string{
+		".........", // 0
+		"..#...#..", // 1 ^ eye peaks
+		".#.#.#.#.", // 2 ^ eye wings
+		"o.......o", // 3 blush cheeks
+		".........", // 4
+		"..#...#..", // 5 big smile corners
+		"...###...", // 6 smile centre
+		".#.....#.", // 7 wide outer smile
+		".........", // 8
+		".........", // 9
+	}},
+}
+
+// slotOffsets defines where each of the three face slots starts on the 34-row matrix.
+// Layout: [0-9] face, [10-11] dark gap, [12-21] face, [22-23] dark gap, [24-33] face.
+var slotOffsets = [3]int{0, 12, 24}
+
+// FaceAnimator runs three independently cycling face slots on the secondary matrix.
+type FaceAnimator struct {
+	tiles    [][faceWidth][faceTileHeight]byte // precomputed per-face tiles
+	patterns []facePattern
+	slots    [3]int        // which face pattern each slot currently shows
+	switched [3]time.Time  // when each slot last changed faces
+}
+
+// NewFaceAnimator precomputes all face tiles and staggers the three slots so they
+// start on different expressions and cycle out of phase.
+func NewFaceAnimator() *FaceAnimator {
+	fa := &FaceAnimator{
+		patterns: facePatterns,
+		tiles:    make([][faceWidth][faceTileHeight]byte, len(facePatterns)),
+	}
+	for i := range facePatterns {
+		fa.tiles[i] = facePatterns[i].toTile()
+	}
+
+	n := len(facePatterns)
+	fa.slots = [3]int{0, n / 3, 2 * n / 3}
+
+	now := time.Now()
+	fa.switched = [3]time.Time{now, now, now}
+
+	return fa
+}
+
+// Tick advances each slot independently when its current face's hold duration expires.
+func (fa *FaceAnimator) Tick() {
+	now := time.Now()
+	for i := range fa.slots {
+		if now.Sub(fa.switched[i]) >= fa.patterns[fa.slots[i]].holdFor {
+			fa.slots[i] = (fa.slots[i] + 1) % len(fa.patterns)
+			fa.switched[i] = now
+		}
+	}
+}
+
+// Frame composes the three active face tiles into a single [9][34]byte matrix frame,
+// with 2-row dark separators between slots.
+func (fa *FaceAnimator) Frame() [faceWidth][34]byte {
+	var frame [faceWidth][34]byte
+	for i, slot := range fa.slots {
+		tile := fa.tiles[slot]
+		offset := slotOffsets[i]
+		for col := 0; col < faceWidth; col++ {
+			for row := 0; row < faceTileHeight; row++ {
+				frame[col][offset+row] = tile[col][row]
+			}
+		}
+	}
+	return frame
+}

--- a/internal/visualizer/faces_test.go
+++ b/internal/visualizer/faces_test.go
@@ -1,0 +1,146 @@
+package visualizer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFacePattern_ToTile_Encoding(t *testing.T) {
+	fp := facePattern{
+		holdFor: time.Second,
+		rows: [faceTileHeight]string{
+			"#........", // row 0: col 0 = full bright
+			"o........", // row 1: col 0 = soft glow
+			".........", // row 2: all off
+			".........",
+			".........",
+			".........",
+			".........",
+			".........",
+			".........",
+			".........",
+		},
+	}
+	tile := fp.toTile()
+
+	if tile[0][0] != 255 {
+		t.Errorf("toTile(): '#' at (col=0,row=0) = %d, want 255", tile[0][0])
+	}
+	if tile[0][1] != 160 {
+		t.Errorf("toTile(): 'o' at (col=0,row=1) = %d, want 160", tile[0][1])
+	}
+	if tile[0][2] != 0 {
+		t.Errorf("toTile(): '.' at (col=0,row=2) = %d, want 0", tile[0][2])
+	}
+	// No other column in row 0 should be lit.
+	for col := 1; col < faceWidth; col++ {
+		if tile[col][0] != 0 {
+			t.Errorf("toTile(): col=%d row=0 = %d, want 0", col, tile[col][0])
+		}
+	}
+}
+
+func TestFaceAnimator_Frame_SlotOffsets(t *testing.T) {
+	fa := NewFaceAnimator()
+	frame := fa.Frame()
+
+	// Each of the three slots occupies rows [offset : offset+faceTileHeight].
+	// The two-row dark gap between them must be zero.
+	gaps := [][2]int{{10, 11}, {22, 23}}
+	for _, g := range gaps {
+		for _, row := range g {
+			for col := 0; col < faceWidth; col++ {
+				if frame[col][row] != 0 {
+					t.Errorf("Frame(): gap row %d col %d = %d, want 0", row, col, frame[col][row])
+				}
+			}
+		}
+	}
+}
+
+func TestFaceAnimator_Frame_NoBoundsOverrun(t *testing.T) {
+	fa := NewFaceAnimator()
+
+	// Cycle through every pattern and verify no write falls outside [0:9][0:34].
+	for i := range fa.patterns {
+		fa.slots[0] = i
+		fa.slots[1] = i
+		fa.slots[2] = i
+		frame := fa.Frame()
+
+		// Frame is [faceWidth][34] — compiler guarantees bounds, but verify
+		// that the last slot's last row (offset 24 + 9 = 33) is within range.
+		_ = frame[faceWidth-1][33]
+	}
+}
+
+func TestFaceAnimator_Frame_TileDataPlacedAtOffset(t *testing.T) {
+	fa := NewFaceAnimator()
+
+	// Force all three slots to pattern 0 so we have a known tile.
+	fa.slots = [3]int{0, 0, 0}
+	tile := fa.tiles[0]
+	frame := fa.Frame()
+
+	// Verify each slot's tile data appears at the right offset.
+	for slotIdx, offset := range slotOffsets {
+		for col := 0; col < faceWidth; col++ {
+			for row := 0; row < faceTileHeight; row++ {
+				got := frame[col][offset+row]
+				want := tile[col][row]
+				if got != want {
+					t.Errorf("slot %d: frame[%d][%d] = %d, want %d (tile[%d][%d])",
+						slotIdx, col, offset+row, got, want, col, row)
+				}
+			}
+		}
+	}
+}
+
+func TestFaceAnimator_Tick_NoAdvanceBeforeHoldExpires(t *testing.T) {
+	fa := NewFaceAnimator()
+	fa.slots = [3]int{0, 0, 0}
+	// Set switched to now — hold has not expired.
+	now := time.Now()
+	fa.switched = [3]time.Time{now, now, now}
+
+	fa.Tick()
+
+	for i, s := range fa.slots {
+		if s != 0 {
+			t.Errorf("slot %d advanced before holdFor expired: got %d, want 0", i, s)
+		}
+	}
+}
+
+func TestFaceAnimator_Tick_AdvancesAfterHoldExpires(t *testing.T) {
+	fa := NewFaceAnimator()
+	fa.slots = [3]int{0, 0, 0}
+	// Set switched far in the past so the hold is definitely expired.
+	past := time.Now().Add(-24 * time.Hour)
+	fa.switched = [3]time.Time{past, past, past}
+
+	fa.Tick()
+
+	for i, s := range fa.slots {
+		if s != 1 {
+			t.Errorf("slot %d did not advance after holdFor expired: got %d, want 1", i, s)
+		}
+	}
+}
+
+func TestFaceAnimator_Tick_CyclesWrapAround(t *testing.T) {
+	fa := NewFaceAnimator()
+	last := len(fa.patterns) - 1
+	fa.slots = [3]int{last, last, last}
+	past := time.Now().Add(-24 * time.Hour)
+	fa.switched = [3]time.Time{past, past, past}
+
+	fa.Tick()
+
+	for i, s := range fa.slots {
+		if s != 0 {
+			t.Errorf("slot %d did not wrap from last to 0: got %d", i, s)
+		}
+	}
+}

--- a/internal/visualizer/gameoflife.go
+++ b/internal/visualizer/gameoflife.go
@@ -37,6 +37,7 @@ func (g *GameOfLife) seed() {
 	}
 	g.gen = 0
 	g.staleCount = 0
+	g.lastAlive = -1
 }
 
 func (g *GameOfLife) neighbors(col, row int) int {

--- a/internal/visualizer/gameoflife.go
+++ b/internal/visualizer/gameoflife.go
@@ -1,29 +1,30 @@
 package visualizer
 
 import (
+	"hash/fnv"
 	"math/rand"
 	"time"
 )
 
 const (
-	golWidth  = 9  // physical columns
-	golHeight = 34 // physical rows
+	golWidth        = 9  // physical columns
+	golHeight       = 34 // physical rows
+	staleHistoryLen = 16 // detect oscillators up to period 16
 )
 
 // GameOfLife runs Conway's Game of Life on a 9×34 LED matrix grid.
 type GameOfLife struct {
-	grid       [golWidth][golHeight]bool
-	rng        *rand.Rand
-	staleCount int
-	lastAlive  int
-	gen        int
+	grid         [golWidth][golHeight]bool
+	recentHashes [staleHistoryLen]uint64
+	rng          *rand.Rand
+	staleCount   int
+	gen          int
 }
 
 // NewGameOfLife creates and randomly seeds a new Game of Life instance.
 func NewGameOfLife() *GameOfLife {
 	g := &GameOfLife{
-		rng:       rand.New(rand.NewSource(time.Now().UnixNano())),
-		lastAlive: -1,
+		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	g.seed()
 	return g
@@ -37,7 +38,25 @@ func (g *GameOfLife) seed() {
 	}
 	g.gen = 0
 	g.staleCount = 0
-	g.lastAlive = -1
+	g.recentHashes = [staleHistoryLen]uint64{}
+}
+
+// gridHash returns a 64-bit FNV-1a hash of the current grid state so that
+// oscillators (blinkers, beehives, spaceships) are detected as stagnant rather
+// than being confused with a stable alive-count.
+func (g *GameOfLife) gridHash() uint64 {
+	h := fnv.New64a()
+	var buf [(golWidth*golHeight + 7) / 8]byte
+	for col := 0; col < golWidth; col++ {
+		for row := 0; row < golHeight; row++ {
+			if g.grid[col][row] {
+				idx := col*golHeight + row
+				buf[idx/8] |= 1 << (uint(idx) % 8)
+			}
+		}
+	}
+	_, _ = h.Write(buf[:])
+	return h.Sum64()
 }
 
 func (g *GameOfLife) neighbors(col, row int) int {
@@ -59,6 +78,9 @@ func (g *GameOfLife) neighbors(col, row int) int {
 }
 
 // Tick advances the simulation by one generation and re-seeds if it stagnates.
+// Stagnation is detected by comparing the current grid hash against the last
+// staleHistoryLen hashes, catching oscillators that the naive alive-count check
+// would miss.
 func (g *GameOfLife) Tick() {
 	var next [golWidth][golHeight]bool
 	alive := 0
@@ -80,14 +102,22 @@ func (g *GameOfLife) Tick() {
 	g.grid = next
 	g.gen++
 
-	if alive == g.lastAlive {
+	h := g.gridHash()
+	stale := false
+	for _, prev := range g.recentHashes {
+		if prev == h {
+			stale = true
+			break
+		}
+	}
+	if stale {
 		g.staleCount++
 	} else {
 		g.staleCount = 0
 	}
-	g.lastAlive = alive
+	g.recentHashes[g.gen%staleHistoryLen] = h
 
-	if g.staleCount >= 8 || alive < 4 {
+	if g.staleCount >= 4 || alive < 4 {
 		g.seed()
 	}
 }

--- a/internal/visualizer/gameoflife.go
+++ b/internal/visualizer/gameoflife.go
@@ -1,0 +1,105 @@
+package visualizer
+
+import (
+	"math/rand"
+	"time"
+)
+
+const (
+	golWidth  = 9  // physical columns
+	golHeight = 34 // physical rows
+)
+
+// GameOfLife runs Conway's Game of Life on a 9×34 LED matrix grid.
+type GameOfLife struct {
+	grid       [golWidth][golHeight]bool
+	rng        *rand.Rand
+	staleCount int
+	lastAlive  int
+	gen        int
+}
+
+// NewGameOfLife creates and randomly seeds a new Game of Life instance.
+func NewGameOfLife() *GameOfLife {
+	g := &GameOfLife{
+		rng:       rand.New(rand.NewSource(time.Now().UnixNano())),
+		lastAlive: -1,
+	}
+	g.seed()
+	return g
+}
+
+func (g *GameOfLife) seed() {
+	for col := range g.grid {
+		for row := range g.grid[col] {
+			g.grid[col][row] = g.rng.Float64() < 0.35
+		}
+	}
+	g.gen = 0
+	g.staleCount = 0
+}
+
+func (g *GameOfLife) neighbors(col, row int) int {
+	n := 0
+	for dc := -1; dc <= 1; dc++ {
+		for dr := -1; dr <= 1; dr++ {
+			if dc == 0 && dr == 0 {
+				continue
+			}
+			// Toroidal wrap so patterns flow continuously on the small grid.
+			c := (col + dc + golWidth) % golWidth
+			r := (row + dr + golHeight) % golHeight
+			if g.grid[c][r] {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// Tick advances the simulation by one generation and re-seeds if it stagnates.
+func (g *GameOfLife) Tick() {
+	var next [golWidth][golHeight]bool
+	alive := 0
+
+	for col := 0; col < golWidth; col++ {
+		for row := 0; row < golHeight; row++ {
+			n := g.neighbors(col, row)
+			switch {
+			case g.grid[col][row] && (n == 2 || n == 3):
+				next[col][row] = true
+				alive++
+			case !g.grid[col][row] && n == 3:
+				next[col][row] = true
+				alive++
+			}
+		}
+	}
+
+	g.grid = next
+	g.gen++
+
+	if alive == g.lastAlive {
+		g.staleCount++
+	} else {
+		g.staleCount = 0
+	}
+	g.lastAlive = alive
+
+	if g.staleCount >= 8 || alive < 4 {
+		g.seed()
+	}
+}
+
+// Frame returns the current grid as a column-major [9][34]byte brightness array.
+func (g *GameOfLife) Frame() [golWidth][golHeight]byte {
+	var f [golWidth][golHeight]byte
+	for col := 0; col < golWidth; col++ {
+		for row := 0; row < golHeight; row++ {
+			if g.grid[col][row] {
+				f[col][row] = 255
+			}
+		}
+	}
+	return f
+}

--- a/internal/visualizer/gameoflife_test.go
+++ b/internal/visualizer/gameoflife_test.go
@@ -1,0 +1,233 @@
+package visualizer
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// newTestGoL returns a zeroed GameOfLife with a fixed RNG — seed() is not called.
+func newTestGoL() *GameOfLife {
+	return &GameOfLife{
+		rng: rand.New(rand.NewSource(42)),
+	}
+}
+
+// addStillBlock places a 2x2 still-life block at (col, row) to keep the alive
+// count >= 4 so the alive<4 reseed threshold doesn't interfere with rule tests.
+// The block must be far enough from the test cells that they don't interact.
+func addStillBlock(g *GameOfLife, col, row int) {
+	g.grid[col][row] = true
+	g.grid[col][row+1] = true
+	g.grid[col+1][row] = true
+	g.grid[col+1][row+1] = true
+}
+
+// TestGameOfLife_Neighbors tests the neighbour-counting function including
+// the toroidal wrap that keeps patterns flowing on the small grid.
+func TestGameOfLife_Neighbors_Center(t *testing.T) {
+	g := newTestGoL()
+	g.grid[3][16] = true
+	g.grid[4][15] = true
+	g.grid[5][17] = true
+
+	if n := g.neighbors(4, 16); n != 3 {
+		t.Errorf("neighbors(4,16) = %d, want 3", n)
+	}
+}
+
+func TestGameOfLife_Neighbors_ToroidalWrap(t *testing.T) {
+	g := newTestGoL()
+	// Cells that are neighbours of (0,0) only via toroidal wrap.
+	g.grid[golWidth-1][golHeight-1] = true // (-1,-1) wrapped
+	g.grid[0][golHeight-1] = true          // (0,-1) wrapped
+	g.grid[golWidth-1][0] = true           // (-1,0) wrapped
+
+	if n := g.neighbors(0, 0); n != 3 {
+		t.Errorf("neighbors(0,0) toroidal = %d, want 3", n)
+	}
+}
+
+func TestGameOfLife_Neighbors_SelfExcluded(t *testing.T) {
+	g := newTestGoL()
+	g.grid[4][16] = true // only the cell itself
+
+	if n := g.neighbors(4, 16); n != 0 {
+		t.Errorf("neighbors(4,16) counted self: got %d, want 0", n)
+	}
+}
+
+// TestGameOfLife_Tick_Birth verifies that a dead cell with exactly 3 live
+// neighbours is born in the next generation.
+func TestGameOfLife_Tick_Birth(t *testing.T) {
+	g := newTestGoL()
+	addStillBlock(g, 7, 30) // background: keeps alive>=4, far from test area
+	// Horizontal blinker at row 15; (4,16) is dead with 3 neighbours below it.
+	g.grid[3][15] = true
+	g.grid[4][15] = true
+	g.grid[5][15] = true
+
+	g.Tick()
+
+	if !g.grid[4][16] {
+		t.Error("Tick(): dead cell with 3 neighbours should be born")
+	}
+}
+
+// TestGameOfLife_Tick_SurvivalWith2 verifies that a live cell with exactly 2
+// live neighbours survives.
+func TestGameOfLife_Tick_SurvivalWith2(t *testing.T) {
+	g := newTestGoL()
+	addStillBlock(g, 7, 30)
+	// Horizontal blinker; centre cell (4,16) has exactly 2 live neighbours.
+	g.grid[3][16] = true
+	g.grid[4][16] = true
+	g.grid[5][16] = true
+
+	g.Tick()
+
+	if !g.grid[4][16] {
+		t.Error("Tick(): live cell with 2 neighbours should survive")
+	}
+}
+
+// TestGameOfLife_Tick_DeathByIsolation verifies that a live cell with 0
+// neighbours dies.
+func TestGameOfLife_Tick_DeathByIsolation(t *testing.T) {
+	g := newTestGoL()
+	addStillBlock(g, 7, 30) // keeps alive>=4 so no population-reseed fires
+	g.grid[4][16] = true    // isolated — 0 neighbours
+
+	g.Tick()
+
+	if g.grid[4][16] {
+		t.Error("Tick(): isolated live cell should die (0 neighbours)")
+	}
+}
+
+// TestGameOfLife_Tick_DeathByOvercrowding verifies that a live cell with more
+// than 3 live neighbours dies.
+func TestGameOfLife_Tick_DeathByOvercrowding(t *testing.T) {
+	g := newTestGoL()
+	addStillBlock(g, 7, 30)
+	g.grid[4][16] = true // centre: 4 neighbours → dies
+	g.grid[3][15] = true
+	g.grid[4][15] = true
+	g.grid[5][15] = true
+	g.grid[3][16] = true
+
+	g.Tick()
+
+	if g.grid[4][16] {
+		t.Error("Tick(): live cell with 4 neighbours should die (overcrowding)")
+	}
+}
+
+// TestGameOfLife_Tick_StillLife_HashStagnation verifies that the hash-based
+// stagnation detector reseeds a 2x2 still-life block (oscillators that maintain
+// a constant alive-count would be missed by the old alive==lastAlive check).
+func TestGameOfLife_Tick_StillLife_HashStagnation(t *testing.T) {
+	g := newTestGoL()
+	// 2x2 block is a still life: same grid hash every generation.
+	g.grid[3][16] = true
+	g.grid[3][17] = true
+	g.grid[4][16] = true
+	g.grid[4][17] = true
+
+	// Tick 1: hash stored for the first time; staleCount stays 0.
+	g.Tick()
+	if g.staleCount != 0 {
+		t.Errorf("tick 1: staleCount = %d, want 0 (first seen hash)", g.staleCount)
+	}
+
+	// Ticks 2-4: same hash detected each time; staleCount climbs to 3.
+	for tick := 2; tick <= 4; tick++ {
+		g.Tick()
+		want := tick - 1
+		if g.staleCount != want {
+			t.Errorf("tick %d: staleCount = %d, want %d", tick, g.staleCount, want)
+		}
+	}
+
+	// Tick 5: staleCount reaches 4 → reseed fires → gen and staleCount reset.
+	g.Tick()
+	if g.gen != 0 {
+		t.Errorf("after still-life reseed: gen = %d, want 0", g.gen)
+	}
+	if g.staleCount != 0 {
+		t.Errorf("after still-life reseed: staleCount = %d, want 0", g.staleCount)
+	}
+}
+
+// TestGameOfLife_Tick_ReseedOnLowPopulation verifies that fewer than 4 live
+// cells triggers an immediate reseed.
+func TestGameOfLife_Tick_ReseedOnLowPopulation(t *testing.T) {
+	g := newTestGoL()
+	// Three mutually non-adjacent isolated cells (no neighbours → all die).
+	// (0,0) and (8,33) would be toroidal neighbours, so use (8,20) instead.
+	g.grid[0][0] = true
+	g.grid[4][16] = true
+	g.grid[8][20] = true
+
+	g.Tick()
+
+	alive := 0
+	for col := range g.grid {
+		for _, cell := range g.grid[col] {
+			if cell {
+				alive++
+			}
+		}
+	}
+	if alive < 4 {
+		t.Errorf("after low-population reseed: alive = %d, want >= 4", alive)
+	}
+}
+
+// TestGameOfLife_Seed_ResetsState verifies that seed() clears generation,
+// stale counter, and hash history.
+func TestGameOfLife_Seed_ResetsState(t *testing.T) {
+	g := newTestGoL()
+	g.gen = 99
+	g.staleCount = 7
+	g.recentHashes[0] = 12345
+	g.recentHashes[5] = 67890
+
+	g.seed()
+
+	if g.gen != 0 {
+		t.Errorf("seed(): gen = %d, want 0", g.gen)
+	}
+	if g.staleCount != 0 {
+		t.Errorf("seed(): staleCount = %d, want 0", g.staleCount)
+	}
+	for i, h := range g.recentHashes {
+		if h != 0 {
+			t.Errorf("seed(): recentHashes[%d] = %d, want 0", i, h)
+		}
+	}
+}
+
+// TestGameOfLife_Frame_MatchesGrid verifies that Frame() maps live cells to 255
+// and dead cells to 0.
+func TestGameOfLife_Frame_MatchesGrid(t *testing.T) {
+	g := newTestGoL()
+	g.grid[0][0] = true
+	g.grid[4][16] = true
+	g.grid[8][33] = true
+
+	f := g.Frame()
+
+	for _, tc := range []struct {
+		col, row int
+		want     byte
+	}{
+		{0, 0, 255},
+		{4, 16, 255},
+		{8, 33, 255},
+		{1, 1, 0},
+	} {
+		if f[tc.col][tc.row] != tc.want {
+			t.Errorf("Frame()[%d][%d] = %d, want %d", tc.col, tc.row, f[tc.col][tc.row], tc.want)
+		}
+	}
+}

--- a/internal/visualizer/mapper.go
+++ b/internal/visualizer/mapper.go
@@ -31,6 +31,8 @@ type MultiDisplayManagerInterface interface {
 	SetBrightness(level byte) error
 	SetUpdateRate(rate time.Duration)
 	HasMultipleDisplays() bool
+	// DrawFrame renders a raw pixel frame on the named matrix (used by animations mode).
+	DrawFrame(name string, frame [9][34]byte) error
 }
 
 // Visualizer converts system metrics into visual patterns for single LED matrix displays.
@@ -45,7 +47,14 @@ type MultiVisualizer struct {
 	multiDisplay MultiDisplayManagerInterface
 	config       *config.Config
 	lastUpdate   time.Time
+	gol          *GameOfLife
+	faces        *FaceAnimator
+	golLastTick  time.Time
 }
+
+// golTickRate controls how fast Game of Life advances. One generation every ~350ms
+// gives a lively but readable simulation on the 9×34 matrix.
+const golTickRate = 350 * time.Millisecond
 
 // NewVisualizer creates a new Visualizer with the specified display manager and configuration.
 func NewVisualizer(display DisplayManagerInterface, cfg *config.Config) *Visualizer {
@@ -60,6 +69,8 @@ func NewMultiVisualizer(multiDisplay MultiDisplayManagerInterface, cfg *config.C
 	return &MultiVisualizer{
 		multiDisplay: multiDisplay,
 		config:       cfg,
+		gol:          NewGameOfLife(),
+		faces:        NewFaceAnimator(),
 	}
 }
 
@@ -248,8 +259,11 @@ func (v *Visualizer) GetCurrentState() map[string]interface{} {
 
 // UpdateDisplay updates multiple LED matrix displays based on system statistics and dual mode configuration.
 func (mv *MultiVisualizer) UpdateDisplay(summary *stats.StatsSummary) error {
-	if time.Since(mv.lastUpdate) < mv.config.Display.UpdateRate {
-		return nil
+	// Animations mode manages its own internal timing; skip the outer rate limiter.
+	if mv.config.Display.Mode != "animations" {
+		if time.Since(mv.lastUpdate) < mv.config.Display.UpdateRate {
+			return nil
+		}
 	}
 
 	switch mv.config.Display.Mode {
@@ -261,9 +275,37 @@ func (mv *MultiVisualizer) UpdateDisplay(summary *stats.StatsSummary) error {
 		return mv.updateActivityMode(summary)
 	case "status":
 		return mv.updateStatusMode(summary)
+	case "animations":
+		return mv.updateAnimationsMode()
 	default:
 		return mv.updatePercentageMode(summary)
 	}
+}
+
+// updateAnimationsMode runs Game of Life on the primary (left) matrix and
+// cycles through kawaii/anime/punk facial expressions on the secondary (right) matrix.
+func (mv *MultiVisualizer) updateAnimationsMode() error {
+	now := time.Now()
+
+	// Advance Game of Life on its own tick rate.
+	if now.Sub(mv.golLastTick) >= golTickRate {
+		mv.gol.Tick()
+		mv.golLastTick = now
+	}
+
+	// Advance face expression on each face's individual hold duration.
+	mv.faces.Tick()
+
+	if err := mv.multiDisplay.DrawFrame("primary", mv.gol.Frame()); err != nil {
+		logging.Warn("animations: failed to draw GoL frame", "error", err)
+	}
+
+	if err := mv.multiDisplay.DrawFrame("secondary", mv.faces.Frame()); err != nil {
+		logging.Warn("animations: failed to draw face frame", "error", err)
+	}
+
+	mv.lastUpdate = now
+	return nil
 }
 
 func (mv *MultiVisualizer) updatePercentageMode(summary *stats.StatsSummary) error {

--- a/internal/visualizer/mapper.go
+++ b/internal/visualizer/mapper.go
@@ -91,6 +91,8 @@ func (v *Visualizer) UpdateDisplay(summary *stats.StatsSummary) error {
 		return v.updateStatusMode(summary)
 	case "custom":
 		return v.updateCustomMode(summary)
+	case "animations":
+		return fmt.Errorf("animations mode requires multiple matrices; configure matrix.matrices in your config")
 	default:
 		return fmt.Errorf("unknown display mode: %s", v.config.Display.Mode)
 	}
@@ -259,11 +261,8 @@ func (v *Visualizer) GetCurrentState() map[string]interface{} {
 
 // UpdateDisplay updates multiple LED matrix displays based on system statistics and dual mode configuration.
 func (mv *MultiVisualizer) UpdateDisplay(summary *stats.StatsSummary) error {
-	// Animations mode manages its own internal timing; skip the outer rate limiter.
-	if mv.config.Display.Mode != "animations" {
-		if time.Since(mv.lastUpdate) < mv.config.Display.UpdateRate {
-			return nil
-		}
+	if time.Since(mv.lastUpdate) < mv.config.Display.UpdateRate {
+		return nil
 	}
 
 	switch mv.config.Display.Mode {
@@ -296,16 +295,20 @@ func (mv *MultiVisualizer) updateAnimationsMode() error {
 	// Advance face expression on each face's individual hold duration.
 	mv.faces.Tick()
 
+	var lastErr error
+
 	if err := mv.multiDisplay.DrawFrame("primary", mv.gol.Frame()); err != nil {
 		logging.Warn("animations: failed to draw GoL frame", "error", err)
+		lastErr = fmt.Errorf("draw primary animation frame: %w", err)
 	}
 
 	if err := mv.multiDisplay.DrawFrame("secondary", mv.faces.Frame()); err != nil {
 		logging.Warn("animations: failed to draw face frame", "error", err)
+		lastErr = fmt.Errorf("draw secondary animation frame: %w", err)
 	}
 
 	mv.lastUpdate = now
-	return nil
+	return lastErr
 }
 
 func (mv *MultiVisualizer) updatePercentageMode(summary *stats.StatsSummary) error {


### PR DESCRIPTION
 ## Summary

Thank you for this repo! Was happy to have something finally working with Windows 11. I added two new animations that I liked for myself but feel free to add onto your repository if you like them!

  - **Left matrix (primary):** Conway's Game of Life running at ~350ms/generation on the 9×34
  portrait grid with toroidal wrapping. Auto-reseeds when the simulation stagnates or population
  collapses.
  - **Right matrix (secondary):** Three independently cycling facial expressions stacked vertically
  on the same matrix. 11 expressions total across kawaii, anime, and punk-rock vibes — each slot
  advances on its own hold timer so they're always out of phase.
  - New `"animations"` display mode wired end-to-end: config validation, visualizer routing, and a
  `DrawFrame` method on `MultiDisplayManager` for raw pixel control via `StageColumn` /
  `FlushColumns`.

  ## New files

  - `internal/visualizer/gameoflife.go` — Conway's Game of Life simulation
  - `internal/visualizer/faces.go` — 11 compact 9×10 face tiles + `FaceAnimator` (3 independent
  slots)

  ## Changed files

  - `internal/matrix/display.go` — `DrawFrame(name, [9][34]byte)` added to `MultiDisplayManager` and
  `MultiDisplayManagerInterface`
  - `internal/visualizer/mapper.go` — `animations` case in `MultiVisualizer.UpdateDisplay`, animation
   state fields, `updateAnimationsMode()`
  - `internal/config/config.go` — `"animations"` added to both validation maps
  - `configs/config.yaml` — default mode set to `animations`, `update_rate` set to `200ms`

  ## Activating

  ```yaml
  # configs/config.yaml
  display:
    mode: "animations"
    update_rate: 200ms

  Or via flags:
  ./bin/framework-led-daemon -mode animations run

  Test plan

  - make build passes with no errors
  - make test passes
  - Daemon runs in animations mode on dual-matrix hardware
  - Game of Life visibly evolves on left matrix and reseeds when stagnant
  - Three faces visible simultaneously on right matrix, cycling independently
  - Other display modes (percentage, gradient, etc.) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "animations" display mode featuring animated facial expressions with multiple expression states and independent cycling, plus Conway's Game of Life simulations with automatic re-seeding.
  * Enhanced display responsiveness by increasing refresh rate from 1s to 200ms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->